### PR TITLE
fix: update azure/openai version and add missing information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "chat-agent-dalle",
       "version": "0.0.1",
       "dependencies": {
-        "@azure/openai": "^1.0.0-beta.7",
+        "@azure/openai": "^1.0.0-beta.11",
         "openai": "^4.17.4",
         "sharp": "^0.32.6"
       },
@@ -41,11 +41,11 @@
       }
     },
     "node_modules/@azure-rest/core-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.1.4.tgz",
-      "integrity": "sha512-RUIQOA8T0WcbNlddr8hjl2MuC5GVRqmMwPXqBVsgvdKesLy+eg3y/6nf3qe2fvcJMI1gF6VtgU5U4hRaR4w4ag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.2.0.tgz",
+      "integrity": "sha512-+3zapvYc+25FpTzCkcYqsh/v8BiSJhMGseWhMgec5RqsH1VovIUHNyNS7hQDECv3QslL6M3TxZnDNmCqoz5IZA==",
       "dependencies": {
-        "@azure/abort-controller": "^1.1.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.5.0",
         "@azure/core-tracing": "^1.0.1",
@@ -53,64 +53,49 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+      "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
       "dependencies": {
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.6.0.tgz",
+      "integrity": "sha512-3X9wzaaGgRaBCwhLQZDtFp5uLIXCPrGbwJNWPPugvL4xbIGgScv77YzzxToKGLAKvG9amDoofMoP+9hsH1vs1w==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-lro": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.4.tgz",
-      "integrity": "sha512-3GJiMVH7/10bulzOKGrrLeG/uCBH/9VtxqaMcB9lIqAeamI/xYQSHJL/KcsLDuH+yTjYpro/u6D/MuRe4dN70Q==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-util": "^1.2.0",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.2.tgz",
-      "integrity": "sha512-wLLJQdL4v1yoqYtEtjKNjf8pJ/G/BqVomAWxcKOR1KbZJyCEnCv04yks7Y1NhJ3JzxbDs307W67uX0JzklFdCg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.14.0.tgz",
+      "integrity": "sha512-Tp4M6NsjCmn9L5p7HsW98eSOS7A0ibl3e5ntZglozT0XuD/0y6i36iW829ZbBq0qihlGgfaeFpkLjZ418KDm1Q==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
         "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
@@ -135,14 +120,14 @@
       }
     },
     "node_modules/@azure/core-sse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-sse/-/core-sse-1.0.0.tgz",
-      "integrity": "sha512-UhsxgWrQaIh6rJynDCNHYDbJ1b3bmqaOex4so8+h0UL4mxyb/og2FHoDJPzgLlvtM4b6/d/klBpwltsxHaZgNA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-sse/-/core-sse-2.0.0.tgz",
+      "integrity": "sha512-PFmmaUwDmcmtt+q9NLzfhwC5qA2ACDn/5fuy8GVxI+YRv2qRvy1C0rZrwZLvOHe//G4cSRMz1X+CekY/Nlem2w==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
@@ -157,15 +142,15 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.7.0.tgz",
+      "integrity": "sha512-Zq2i3QO6k9DA8vnm29mYM4G8IE9u1mhF1GUabVEqPNX8Lj833gdxQ2NAFxt2BZsfAL+e9cT8SyVN7dFVJ/Hf0g==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -180,50 +165,20 @@
       }
     },
     "node_modules/@azure/openai": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@azure/openai/-/openai-1.0.0-beta.7.tgz",
-      "integrity": "sha512-LhZXgEGOoDBYyLDnSe5XwkLM5OUC8RppVW1X6+IrmmGnonsaa0POQ2BYr45YAqlpggtATYRVUbmyLi5SxMzhLg==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@azure/openai/-/openai-1.0.0-beta.11.tgz",
+      "integrity": "sha512-OXS27xkG1abiGf5VZUKnkJKr1VCo8+6EUrTGW5aSVjc5COqX8jAUqVAOZsQVCHBdtWYSBULlZkc0ncKMTRQAiQ==",
       "dependencies": {
-        "@azure-rest/core-client": "^1.1.4",
+        "@azure-rest/core-client": "^1.1.7",
         "@azure/core-auth": "^1.4.0",
-        "@azure/core-lro": "^2.5.3",
-        "@azure/core-rest-pipeline": "^1.12.2",
-        "@azure/core-sse": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.13.0",
+        "@azure/core-sse": "^2.0.0",
+        "@azure/core-util": "^1.4.0",
         "@azure/logger": "^1.0.3",
-        "form-data-encoder": "^3.0.0",
-        "formdata-node": "^5.0.0",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/openai/node_modules/form-data-encoder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-3.0.1.tgz",
-      "integrity": "sha512-f8HPYqVUtZcpe+eg0xxDXryMxfFMZdNQZVXs3KOY3nSeLUDQBaz3w3UUVXJSgR266pgW4ruwnvV5JR+cJJD6dw==",
-      "engines": {
-        "node": ">= 16.5"
-      }
-    },
-    "node_modules/@azure/openai/node_modules/formdata-node": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-5.0.1.tgz",
-      "integrity": "sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
-    "node_modules/@azure/openai/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
           "roblourens.chat-agent-dalle.azureEndpoint": {
             "type": "string",
             "description": "The azure endpoint to make AI requests to, to generate images"
+          },
+          "roblourens.chat-agent-dalle.deploymentName": {
+            "type": "string",
+            "description": "The deployment name of the Dall-E model to use"
           }
         }
       }
@@ -63,7 +67,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@azure/openai": "^1.0.0-beta.7",
+    "@azure/openai": "^1.0.0-beta.11",
     "openai": "^4.17.4",
     "sharp": "^0.32.6"
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,7 +179,7 @@ async function getAiImage(extContext: vscode.ExtensionContext, imageGenPrompt: s
 	const openai = azureEndpoint ? new OpenAIClient(azureEndpoint, new AzureKeyCredential(key)) : new OpenAI({ apiKey: key });
 	let resultUrl = '';
 	if (azureEndpoint && openai instanceof OpenAIClient) {
-		const imageResponse = await openai.getImages(imageGenPrompt, {
+		const imageResponse = await openai.getImages(getAzureDeploymentName(),imageGenPrompt, {
 			n: 1,
 			size: '1024x1024',
 		});
@@ -215,6 +215,10 @@ async function getAiImage(extContext: vscode.ExtensionContext, imageGenPrompt: s
 
 function getAzureEndpoint() {
 	return vscode.workspace.getConfiguration('roblourens.chat-agent-dalle').get<string>('azureEndpoint');
+}
+
+function getAzureDeploymentName() {
+	return vscode.workspace.getConfiguration('roblourens.chat-agent-dalle').get<string>('deploymentName');
 }
 
 const openAIKeyName = 'openai.aiKey';


### PR DESCRIPTION
This PR updates the version of `@azure/openai` to the latest beta version.
The version we had before wasn't passing the deployment name so a resource couldn't be find when calling `getImages`.