### PR TITLE
fix: update to latest api changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,22 @@
   },
   "enabledApiProposals": [
     "chatParticipant",
-    "languageModels"
+    "languageModels",
+    "defaultChatParticipant"
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "chatParticipants": [
+      {
+        "name": "dall-e",
+        "description": "Use Dall-E",
+        "commands": [
+          { "name": "affirmation", "description": "Sometimes we need a context-aware affirmation from a happy cute animal!" },
+          { "name": "flow", "description": "Visualize the code flow based for the current code" },
+          { "name": "render", "description": "Preview the current code as website rendering" }
+        ]
+      }
+    ],
     "configuration": [
       {
         "title": "Dall-E Chat Agent",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "enabledApiProposals": [
     "chatParticipant",
-    "languageModels",
-    "defaultChatParticipant"
+    "languageModels"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,6 @@ export function activate(extContext: vscode.ExtensionContext) {
 		if (git && typeof value === 'string') {
 			let fullBranchName = value.match(/Current Branch name: (.*)/i)![1];
 			const branchName = fullBranchName.split('/')[1] || fullBranchName;
-			// const access = await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID);
 			const promptRequest = await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID, [
 				new vscode.LanguageModelChatSystemMessage('You write creative prompts for an AI image generator. The user will give a short phrase, and you must generate a prompt for DALL-E based on that phrase. Don\'t forget to include the art style for the image. For example, it could be an oil painting, a photograph, a cartoon, a charcoal drawing, or something else. Reply with the prompt and no other text.'),
 				new vscode.LanguageModelChatUserMessage(branchName),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,10 +33,10 @@ export function activate(extContext: vscode.ExtensionContext) {
 		if (git && typeof value === 'string') {
 			let fullBranchName = value.match(/Current Branch name: (.*)/i)![1];
 			const branchName = fullBranchName.split('/')[1] || fullBranchName;
-			const access = await vscode.lm.requestLanguageModelAccess(LANGUAGE_MODEL_ID);
-			const promptRequest = access.makeChatRequest([
-				new vscode.LanguageModelSystemMessage('You write creative prompts for an AI image generator. The user will give a short phrase, and you must generate a prompt for DALL-E based on that phrase. Don\'t forget to include the art style for the image. For example, it could be an oil painting, a photograph, a cartoon, a charcoal drawing, or something else. Reply with the prompt and no other text.'),
-				new vscode.LanguageModelUserMessage(branchName),
+			// const access = await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID);
+			const promptRequest = await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID, [
+				new vscode.LanguageModelChatSystemMessage('You write creative prompts for an AI image generator. The user will give a short phrase, and you must generate a prompt for DALL-E based on that phrase. Don\'t forget to include the art style for the image. For example, it could be an oil painting, a photograph, a cartoon, a charcoal drawing, or something else. Reply with the prompt and no other text.'),
+				new vscode.LanguageModelChatUserMessage(branchName),
 			], {}, token);
 
 			let prompt = '';
@@ -63,17 +63,6 @@ Have a great day!`;
 		return {};
 	});
 
-	agent.description = 'Use Dall-E';
-	agent.fullName = 'Dall-E';
-	agent.commandProvider = {
-		provideCommands(token) {
-			return [
-				{ name: 'affirmation', description: 'Sometimes we need a context-aware affirmation from a happy cute animal!' },
-				{ name: 'flow', description: 'Visualize the code flow based for the current code' },
-				{ name: 'render', description: 'Preview the current code as website rendering' },
-			];
-		},
-	};
 	agent.iconPath = new vscode.ThemeIcon('sparkle');
 
 	extContext.subscriptions.push(agent);
@@ -87,14 +76,13 @@ async function handleAffirmation(extContext: vscode.ExtensionContext, request: v
 	const diff = await gitExtension?.exports.getAPI(1).repositories[0].diff();
 	console.log(diff);
 
-	const access = await vscode.lm.requestLanguageModelAccess(LANGUAGE_MODEL_ID);
 	const promptRequest = diff ?
-		access.makeChatRequest([
-			new vscode.LanguageModelSystemMessage('Here is a user\'s git diff. Please write a very short one-sentence compliment about the added lines of code. MUST be fewer than 10 words, but it should focus on one part of the code in detail. It should be over-the-top complimentary and use exclamation marks! Do not use emoji.'),
-			new vscode.LanguageModelUserMessage(diff)
+		await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID, [
+			new vscode.LanguageModelChatSystemMessage('Here is a user\'s git diff. Please write a very short one-sentence compliment about the added lines of code. MUST be fewer than 10 words, but it should focus on one part of the code in detail. It should be over-the-top complimentary and use exclamation marks! Do not use emoji.'),
+			new vscode.LanguageModelChatUserMessage(diff)
 		], {}, token) :
-		access.makeChatRequest([
-			new vscode.LanguageModelSystemMessage('Write a motivational message for a programmer. It should be over-the-top complimentary and use exclamation marks! And tell them that they are good at what they do. Less than 10 words.')
+		await vscode.lm.sendChatRequest(LANGUAGE_MODEL_ID, [
+			new vscode.LanguageModelChatSystemMessage('Write a motivational message for a programmer. It should be over-the-top complimentary and use exclamation marks! And tell them that they are good at what they do. Less than 10 words.')
 		], {}, token);
 
 	let prompt = '';

--- a/src/vscode.proposed.languageModels.d.ts
+++ b/src/vscode.proposed.languageModels.d.ts
@@ -8,20 +8,14 @@ declare module 'vscode' {
 	/**
 	 * Represents a language model response.
 	 *
-	 * @see {@link LanguageModelAccess.makeChatRequest}
+	 * @see {@link LanguageModelAccess.chatRequest}
 	 */
-	export interface LanguageModelResponse {
-
-		/**
-		 * The overall result of the request which represents failure or success
-		 * but. The concrete value is not specified and depends on the selected language model.
-		 *
-		 * *Note* that the actual response represented by the {@link LanguageModelResponse.stream `stream`}-property
-		 */
-		result: Thenable<unknown>;
+	export interface LanguageModelChatResponse {
 
 		/**
 		 * An async iterable that is a stream of text chunks forming the overall response.
+		 *
+		 * *Note* that this stream will error when during data receiving an error occurrs.
 		 */
 		stream: AsyncIterable<string>;
 	}
@@ -35,7 +29,7 @@ declare module 'vscode' {
 	 * *Note* that a language model may choose to add additional system messages to the ones
 	 * provided by extensions.
 	 */
-	export class LanguageModelSystemMessage {
+	export class LanguageModelChatSystemMessage {
 
 		/**
 		 * The content of this message.
@@ -53,7 +47,7 @@ declare module 'vscode' {
 	/**
 	 * A language model message that represents a user message.
 	 */
-	export class LanguageModelUserMessage {
+	export class LanguageModelChatUserMessage {
 
 		/**
 		 * The content of this message.
@@ -78,7 +72,7 @@ declare module 'vscode' {
 	 * A language model message that represents an assistant message, usually in response to a user message
 	 * or as a sample response/reply-pair.
 	 */
-	export class LanguageModelAssistantMessage {
+	export class LanguageModelChatAssistantMessage {
 
 		/**
 		 * The content of this message.
@@ -93,50 +87,10 @@ declare module 'vscode' {
 		constructor(content: string);
 	}
 
-	export type LanguageModelMessage = LanguageModelSystemMessage | LanguageModelUserMessage | LanguageModelAssistantMessage;
-
 	/**
-	 * Represents access to using a language model. Access can be revoked at any time and extension
-	 * must check if the access is {@link LanguageModelAccess.isRevoked still valid} before using it.
+	 * Different types of language model messages.
 	 */
-	export interface LanguageModelAccess {
-
-		/**
-		 * Whether the access to the language model has been revoked.
-		 */
-		readonly isRevoked: boolean;
-
-		/**
-		 * An event that is fired when the access the language model has has been revoked or re-granted.
-		 */
-		// TODO@API NAME?
-		readonly onDidChangeAccess: Event<void>;
-
-		/**
-		 * The name of the model.
-		 *
-		 * It is expected that the model name can be used to lookup properties like token limits or what
-		 * `options` are available.
-		 */
-		readonly model: string;
-
-		/**
-		 * Make a request to the language model.
-		 *
-		 * *Note:* This will throw an error if access has been revoked.
-		 *
-		 * @param messages
-		 * @param options
-		 */
-		makeChatRequest(messages: LanguageModelMessage[], options: { [name: string]: any }, token: CancellationToken): LanguageModelResponse;
-	}
-
-	export interface LanguageModelAccessOptions {
-		/**
-		 * A human-readable message that explains why access to a language model is needed and what feature is enabled by it.
-		 */
-		justification?: string;
-	}
+	export type LanguageModelChatMessage = LanguageModelChatSystemMessage | LanguageModelChatUserMessage | LanguageModelChatAssistantMessage;
 
 	/**
 	 * An event describing the change in the set of available language models.
@@ -153,23 +107,89 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * An error type for language model specific errors.
+	 *
+	 * Consumers of language models should check the code property to determine specific
+	 * failure causes, like `if(someError.code === vscode.LanguageModelError.NotFound.name) {...}`
+	 * for the case of referring to an unknown language model. For unspecified errors the `cause`-property
+	 * will contain the actual error.
+	 */
+	export class LanguageModelError extends Error {
+
+		/**
+		 * The language model does not exist.
+		 */
+		static NotFound(message?: string): LanguageModelError;
+
+		/**
+		 * The requestor does not have permissions to use this
+		 * language model
+		 */
+		static NoPermissions(message?: string): LanguageModelError;
+
+		/**
+		 * A code that identifies this error.
+		 *
+		 * Possible values are names of errors, like {@linkcode LanguageModelError.NotFound NotFound},
+		 * or `Unknown` for unspecified errors from the language model itself. In the latter case the
+		 * `cause`-property will contain the actual error.
+		 */
+		readonly code: string;
+	}
+
+	/**
+	 * Options for making a chat request using a language model.
+	 *
+	 * @see {@link lm.chatRequest}
+	 */
+	export interface LanguageModelChatRequestOptions {
+
+		/**
+		 * A human-readable message that explains why access to a language model is needed and what feature is enabled by it.
+		 */
+		justification?: string;
+
+		/**
+		 * Do not show the consent UI if the user has not yet granted access to the language model but fail the request instead.
+		 */
+		// TODO@API Revisit this, how do you do the first request?
+		silent?: boolean;
+
+		/**
+		 * A set of options that control the behavior of the language model. These options are specific to the language model
+		 * and need to be lookup in the respective documentation.
+		 */
+		modelOptions?: { [name: string]: any };
+	}
+
+	/**
 	 * Namespace for language model related functionality.
 	 */
 	export namespace lm {
 
 		/**
-		 * Request access to a language model.
+		 * Make a chat request using a language model.
 		 *
-		 * - *Note 1:* This function will throw an error when the user didn't grant access or when the
-		 * requested language model is not available.
+		 * - *Note 1:* language model use may be subject to access restrictions and user consent.
 		 *
-		 * - *Note 2:* It is OK to hold on to the returned access object and use it later, but extensions
-		 * should check {@link LanguageModelAccess.isRevoked} before using it.
+		 * - *Note 2:* language models are contributed by other extensions and as they evolve and change,
+		 * the set of available language models may change over time. Therefore it is strongly recommend to check
+		 * {@link languageModels} for aviailable values and handle missing language models gracefully.
 		 *
-		 * @param id The id of the language model, see {@link languageModels} for valid values.
-		 * @returns A thenable that resolves to a language model access object, rejects if access wasn't granted
+		 * This function will return a rejected promise if making a request to the language model is not
+		 * possible. Reasons for this can be:
+		 *
+		 * - user consent not given, see {@link LanguageModelError.NoPermissions `NoPermissions`}
+		 * - model does not exist, see {@link LanguageModelError.NotFound `NotFound`}
+		 * - quota limits exceeded, see {@link LanguageModelError.cause `LanguageModelError.cause`}
+		 *
+		 * @param languageModel A language model identifier.
+		 * @param messages An array of message instances.
+		 * @param options Options that control the request.
+		 * @param token A cancellation token which controls the request. See {@link CancellationTokenSource} for how to create one.
+		 * @returns A thenable that resolves to a {@link LanguageModelChatResponse}. The promise will reject when the request couldn't be made.
 		 */
-		export function requestLanguageModelAccess(id: string, options?: LanguageModelAccessOptions): Thenable<LanguageModelAccess>;
+		export function sendChatRequest(languageModel: string, messages: LanguageModelChatMessage[], options: LanguageModelChatRequestOptions, token: CancellationToken): Thenable<LanguageModelChatResponse>;
 
 		/**
 		 * The identifiers of all language models that are currently available.
@@ -180,5 +200,41 @@ declare module 'vscode' {
 		 * An event that is fired when the set of available language models changes.
 		 */
 		export const onDidChangeLanguageModels: Event<LanguageModelChangeEvent>;
+	}
+
+	/**
+	 * Represents extension specific information about the access to language models.
+	 */
+	export interface LanguageModelAccessInformation {
+
+		/**
+		 * An event that fires when access information changes.
+		 */
+		onDidChange: Event<void>;
+
+		/**
+		 * Checks if a request can be made to a language model.
+		 *
+		 * *Note* that calling this function will not trigger a consent UI but just checks.
+		 *
+		 * @param languageModelId A language model identifier.
+		 * @return `true` if a request can be made, `false` if not, `undefined` if the language
+		 * model does not exist or consent hasn't been asked for.
+		 */
+		canSendRequest(languageModelId: string): boolean | undefined;
+
+		// TODO@API SYNC or ASYNC?
+		// TODO@API future
+		// retrieveQuota(languageModelId: string): { remaining: number; resets: Date };
+	}
+
+	export interface ExtensionContext {
+
+		/**
+		 * An object that keeps information about how this extension can use language models.
+		 *
+		 * @see {@link lm.sendChatRequest}
+		 */
+		readonly languageModelAccessInformation: LanguageModelAccessInformation;
 	}
 }


### PR DESCRIPTION
This PR fixes the example to work with the latest vscode insiders version using `chatParticipants` in `package.json` and `sendChatRequest` instead of `requestLanguageModelAccess` and `makeChatRequest`.
Hope I didn't miss anything but this example now works locally for me :)